### PR TITLE
chore(maintenance): add one-command clean+verify workflow

### DIFF
--- a/governance/source_manifest.json
+++ b/governance/source_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-03-08T22:13:09.333Z",
-  "commit": "b91e46c0b8e2a99a4535059ee2165f4cb69b354a",
+  "generatedAt": "2026-03-08T22:38:04.477Z",
+  "commit": "0e6317d7080ec205959dcb16a3bfba6596db804f",
   "files": {
     ".dockerignore": "6dc97195ab9e47b899923d16bb55b2f2ac94718e3ee55d064617b829d9d491e2",
     ".githooks/pre-push": "e29e08a3bf263114be9cd6876fe9c2cde6f11dff413c6efa9033db3eb1cf6e45",
@@ -306,7 +306,7 @@
     "governance/THREAT_LEDGER.jsonl": "5ea48724895a4a30d6f2602c45983f35ae0672547f09afa0396910da2f008634",
     "governance/branch_protection_policy.json": "d7539f6305083a52324b839a366c1645ad98e48f25a4cededf30b8b3624e7ea5",
     "package-lock.json": "36d1c85077dc2488fce54d902732e5c58567636137b38f246fb224efe9918aa4",
-    "package.json": "b5a31351906f362f724a13f4e4757979eaac4d75feb8d85f5442a76a615e11e0",
+    "package.json": "e2c57f7fd477e5a304569fa9064dcc437d8703ddd53e3d7c20e16772b3afedd5",
     "production-server.js": "3415d790f5cc37bfe04dfe94ac07e026cdc40496713ba538b76894197692ab1e",
     "proof/latest/proof-manifest.json": "366beca59d6c08d281ae059db5498db72ef906bdd9ec5b757806a166f75dbb54",
     "proof/latest/runtime/config.json": "04462a347748134d8e1e19d481c94436d60575a25d666172288e8de14880127e",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "verify:ship": "npm run icons:generate && npm run release:worktree:strict && npm run lint && npm run test:flaky && npm run coverage:check && npm run security:pass:local && npm run build && npm run release:gate:strict && npm run canary:gate && npm run release:manifest && npm run release:sign && npm run release:verify:signature && npm run release:status && npm run release:checksums && npm run release:verify:fresh:strict && npm run kpi:operator && npm run slo:gate && npm run perf:gate",
     "verify:strict": "npm run verify:ship && npm run benchmark:regression && npm run redteam:nightly && npm run replay:autonomy",
     "verify:all": "npm run lint && npm run test:flaky && npm run coverage:check && npm run build",
+    "maintain:verify": "node scripts/maintenance-clean-verify.js",
+    "maintain:clean": "node scripts/maintenance-clean-verify.js --skip-verify",
     "icons:generate": "node tear/generate-icons.js",
     "build": "electron-builder",
     "dist": "electron-builder --publish never",

--- a/scripts/maintenance-clean-verify.js
+++ b/scripts/maintenance-clean-verify.js
@@ -1,0 +1,216 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const root = path.resolve(__dirname, "..");
+const skipVerify = process.argv.includes("--skip-verify");
+const aggressiveTemp = process.argv.includes("--aggressive-temp");
+const tempMaxAgeDaysArg = process.argv.find((arg) => arg.startsWith("--temp-max-age-days="));
+const tempMaxAgeDays = tempMaxAgeDaysArg ? Number(tempMaxAgeDaysArg.split("=")[1]) : 2;
+const verifyCommand = process.env.NEURALSHELL_MAINTENANCE_VERIFY_COMMAND || "npm run verify:all";
+
+function formatBytes(bytes) {
+  const value = Number(bytes || 0);
+  if (!Number.isFinite(value) || value <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let size = value;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(unitIndex === 0 ? 0 : 2)} ${units[unitIndex]}`;
+}
+
+function safeLstat(targetPath) {
+  try {
+    return fs.lstatSync(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function getPathSize(targetPath) {
+  const stat = safeLstat(targetPath);
+  if (!stat) {
+    return 0;
+  }
+  if (stat.isSymbolicLink() || stat.isFile()) {
+    return stat.size;
+  }
+  if (!stat.isDirectory()) {
+    return 0;
+  }
+
+  let total = 0;
+  let entries = [];
+  try {
+    entries = fs.readdirSync(targetPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      total += getPathSize(entryPath);
+      continue;
+    }
+    if (entry.isFile() || entry.isSymbolicLink()) {
+      total += getPathSize(entryPath);
+    }
+  }
+  return total;
+}
+
+function removePath(targetPath) {
+  try {
+    fs.rmSync(targetPath, { recursive: true, force: true, maxRetries: 1 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getElectronBuilderCachePaths() {
+  const home = os.homedir();
+  const localAppData = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+
+  if (process.platform === "win32") {
+    return [path.join(localAppData, "electron-builder", "Cache")];
+  }
+  if (process.platform === "darwin") {
+    return [path.join(home, "Library", "Caches", "electron-builder")];
+  }
+  return [path.join(home, ".cache", "electron-builder")];
+}
+
+function cleanTargetedPaths(targets) {
+  const results = [];
+  for (const target of targets) {
+    if (!fs.existsSync(target)) {
+      continue;
+    }
+    const sizeBefore = getPathSize(target);
+    const removed = removePath(target);
+    results.push({
+      path: target,
+      removed,
+      bytes: removed ? sizeBefore : 0
+    });
+  }
+  return results;
+}
+
+function cleanTempEntries() {
+  const tmpDir = os.tmpdir();
+  if (!fs.existsSync(tmpDir)) {
+    return [];
+  }
+
+  const now = Date.now();
+  const maxAgeMs = Math.max(0, Number.isFinite(tempMaxAgeDays) ? tempMaxAgeDays : 2) * 24 * 60 * 60 * 1000;
+  const patterns = [/^ns[a-z0-9]+\.tmp$/i, /^icon-gen-/i, /^electron-builder-/i, /^neuralshell-smoke-userdata/i];
+  const results = [];
+
+  let entries = [];
+  try {
+    entries = fs.readdirSync(tmpDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const name = entry.name;
+    const fullPath = path.join(tmpDir, name);
+    const stat = safeLstat(fullPath);
+    if (!stat) {
+      continue;
+    }
+
+    const targeted = patterns.some((pattern) => pattern.test(name));
+    const oldEnough = now - stat.mtimeMs >= maxAgeMs;
+    const shouldRemove = targeted || (aggressiveTemp && oldEnough);
+    if (!shouldRemove) {
+      continue;
+    }
+
+    const sizeBefore = getPathSize(fullPath);
+    const removed = removePath(fullPath);
+    results.push({
+      path: fullPath,
+      removed,
+      bytes: removed ? sizeBefore : 0
+    });
+  }
+
+  return results;
+}
+
+function runCommand(command, label) {
+  console.log(`[maintenance] ${label}: ${command}`);
+  const result = spawnSync(command, {
+    cwd: root,
+    stdio: "inherit",
+    shell: true
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${result.status}`);
+  }
+}
+
+function summarize(results) {
+  const removedItems = results.filter((item) => item.removed);
+  const failedItems = results.filter((item) => !item.removed);
+  const reclaimed = removedItems.reduce((sum, item) => sum + Number(item.bytes || 0), 0);
+
+  console.log(`[maintenance] removed items: ${removedItems.length}`);
+  console.log(`[maintenance] failed removals: ${failedItems.length}`);
+  console.log(`[maintenance] reclaimed: ${formatBytes(reclaimed)}`);
+}
+
+function main() {
+  console.log(`[maintenance] repo: ${root}`);
+  console.log(`[maintenance] mode: ${skipVerify ? "clean-only" : "clean+verify"}`);
+  if (aggressiveTemp) {
+    console.log(`[maintenance] aggressive temp cleanup enabled (max age ${tempMaxAgeDays} days).`);
+  }
+
+  const repoTargets = [
+    path.join(root, "dist"),
+    path.join(root, "dist_fresh"),
+    path.join(root, "coverage"),
+    path.join(root, ".nyc_output")
+  ];
+
+  const cleanupResults = [
+    ...cleanTargetedPaths(repoTargets),
+    ...cleanTargetedPaths(getElectronBuilderCachePaths()),
+    ...cleanTempEntries()
+  ];
+
+  summarize(cleanupResults);
+
+  if (skipVerify) {
+    console.log("[maintenance] verify step skipped.");
+    return;
+  }
+
+  runCommand(verifyCommand, "verify");
+  console.log("[maintenance] completed.");
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[maintenance] ${err.message || err}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add scripts/maintenance-clean-verify.js to run safe cleanup of rebuildable artifacts/temp and optionally run full verification
- add npm shortcuts:
  - 
pm run maintain:verify
  - 
pm run maintain:clean
- refresh governance/source_manifest.json for strict source-integrity alignment

## Validation
- ran 
pm run maintain:verify successfully end-to-end
- ran 
pm run security:pass:local successfully after manifest refresh
