### PR TITLE
docs(release): add v1.1.9 stability dossier

### DIFF
--- a/release/postrelease/v1.1.9-OMEGA/STABILITY_REPORT.md
+++ b/release/postrelease/v1.1.9-OMEGA/STABILITY_REPORT.md
@@ -1,0 +1,46 @@
+# NeuralShell v1.1.9-OMEGA Stability Report
+
+Generated: 2026-03-09 (America/Los_Angeles)  
+Release tag: `v1.1.9-OMEGA`  
+Release URL: https://github.com/Z3r0DayZion-install/NeuralShell/releases/tag/v1.1.9-OMEGA  
+Release workflow run: https://github.com/Z3r0DayZion-install/NeuralShell/actions/runs/22869881699
+
+## Scope
+
+- Post-release canary validation across short, medium, hard, and longer-hard profiles.
+- Real-machine upgrade probe from `1.1.8-OMEGA` to `1.1.9-OMEGA`.
+- Installer and release asset publication verification.
+
+## Canary Results
+
+| Profile | File | Passed | Cycles | Uptime Threshold | Min Uptime | Max Uptime | Avg Uptime |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Short | `canary-gate.short.json` | Yes | 3 | 750 ms | 886 ms | 902 ms | 892.3 ms |
+| Medium | `canary-gate.medium.json` | Yes | 8 | 750 ms | 873 ms | 893 ms | 883.1 ms |
+| Hard | `canary-gate.hard.json` | Yes | 16 | 850 ms | 850 ms | 904 ms | 877.3 ms |
+| Harder | `canary-gate.harder.json` | Yes | 24 | 850 ms | 854 ms | 895 ms | 874.5 ms |
+
+Artifacts:
+
+- `release/postrelease/v1.1.9-OMEGA/canary-gate.short.json`
+- `release/postrelease/v1.1.9-OMEGA/canary-gate.medium.json`
+- `release/postrelease/v1.1.9-OMEGA/canary-gate.hard.json`
+- `release/postrelease/v1.1.9-OMEGA/canary-gate.harder.json`
+
+## Real-Machine Upgrade Probe
+
+Report file: `release/postrelease/v1.1.9-OMEGA/realpath-upgrade-validation.json`
+
+- Mode: `forced-installdir-silent-upgrade-probe`
+- Source installer: `NeuralShell.Setup.1.1.8-OMEGA.exe`
+- Target installer: `NeuralShell.Setup.1.1.9-OMEGA.exe`
+- Old installer exit: `0`
+- New installer exit: `0`
+- Old smoke exit: `0` (uptime: `883 ms`)
+- New smoke exit: `0` (uptime: `881 ms`)
+- Findings: none
+- Verdict: pass
+
+## Final Verdict
+
+`v1.1.9-OMEGA` meets release stability criteria from automated post-release evidence in this repository and is approved as a stable line.

--- a/release/postrelease/v1.1.9-OMEGA/stability-summary.json
+++ b/release/postrelease/v1.1.9-OMEGA/stability-summary.json
@@ -1,0 +1,62 @@
+{
+  "generatedAt": "2026-03-09T12:50:00-07:00",
+  "version": "1.1.9-OMEGA",
+  "releaseUrl": "https://github.com/Z3r0DayZion-install/NeuralShell/releases/tag/v1.1.9-OMEGA",
+  "releaseWorkflowRun": "https://github.com/Z3r0DayZion-install/NeuralShell/actions/runs/22869881699",
+  "canary": [
+    {
+      "profile": "short",
+      "file": "canary-gate.short.json",
+      "passed": true,
+      "cycles": 3,
+      "thresholdMinUptimeMs": 750,
+      "minUptimeMs": 886,
+      "maxUptimeMs": 902,
+      "avgUptimeMs": 892.3
+    },
+    {
+      "profile": "medium",
+      "file": "canary-gate.medium.json",
+      "passed": true,
+      "cycles": 8,
+      "thresholdMinUptimeMs": 750,
+      "minUptimeMs": 873,
+      "maxUptimeMs": 893,
+      "avgUptimeMs": 883.1
+    },
+    {
+      "profile": "hard",
+      "file": "canary-gate.hard.json",
+      "passed": true,
+      "cycles": 16,
+      "thresholdMinUptimeMs": 850,
+      "minUptimeMs": 850,
+      "maxUptimeMs": 904,
+      "avgUptimeMs": 877.3
+    },
+    {
+      "profile": "harder",
+      "file": "canary-gate.harder.json",
+      "passed": true,
+      "cycles": 24,
+      "thresholdMinUptimeMs": 850,
+      "minUptimeMs": 854,
+      "maxUptimeMs": 895,
+      "avgUptimeMs": 874.5
+    }
+  ],
+  "upgradeValidation": {
+    "file": "realpath-upgrade-validation.json",
+    "fromVersion": "1.1.8-OMEGA",
+    "toVersion": "1.1.9-OMEGA",
+    "passed": true,
+    "oldInstallExitCode": 0,
+    "newInstallExitCode": 0,
+    "oldSmokeExitCode": 0,
+    "newSmokeExitCode": 0,
+    "oldSmokeUptimeMs": 883,
+    "newSmokeUptimeMs": 881,
+    "findings": []
+  },
+  "stable": true
+}


### PR DESCRIPTION
## Summary\n- add postrelease stability report for v1.1.9-OMEGA\n- add machine-readable stability summary JSON\n- include canary (short/medium/hard/harder) and real upgrade validation evidence\n\n## Evidence\n- release workflow: https://github.com/Z3r0DayZion-install/NeuralShell/actions/runs/22869881699\n- report path: release/postrelease/v1.1.9-OMEGA/STABILITY_REPORT.md\n\n## Validation\n- pre-push governance gate passed (lint/test/coverage/security/integrity)\n