### PR TITLE
docs(beta): add v1.2.1 pilot packet + runboard

### DIFF
--- a/docs/pilots/BETA_BUG_REPORT_TEMPLATE.md
+++ b/docs/pilots/BETA_BUG_REPORT_TEMPLATE.md
@@ -1,0 +1,66 @@
+# NeuralShell Beta Bug Report Template
+
+Use one report per issue. Keep steps exact and minimal.
+
+## Quick Severity Scale
+- `P0` Critical: install/launch blocked, data loss, security compromise, or unrecoverable crash.
+- `P1` High: major feature broken, no practical workaround.
+- `P2` Medium: feature partially broken, workaround exists.
+- `P3` Low: cosmetic/docs/minor friction, no functional impact.
+
+## Copy/Paste Report
+
+```md
+# Bug: <short title>
+
+## Metadata
+- Build: v1.2.1-OMEGA
+- Date found: YYYY-MM-DD
+- Time found: HH:MM (timezone)
+- Tester: <name or alias>
+- Environment: <Windows version, CPU/RAM, AV/EDR if relevant>
+- Severity: P0 | P1 | P2 | P3
+- Checklist step: <step number from beta checklist>
+
+## Summary
+<one-paragraph description of what failed and why it matters>
+
+## Reproduction Steps
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+## Expected Result
+<what should happen>
+
+## Actual Result
+<what actually happened>
+
+## Frequency
+- [ ] Every time
+- [ ] Intermittent
+- [ ] Happened once
+- Repro rate: <e.g., 3/5 runs>
+
+## Impact
+- User impact: <blocked / degraded / minor>
+- Scope: <all users / first-time users / specific environment>
+
+## Evidence
+- Screenshot/video: <path or link>
+- Log file path: <path>
+- Console output/error text: <paste exact error text>
+
+## Workaround
+<none / temporary workaround details>
+
+## Regression Check
+- [ ] Worked in previous version
+- Previous version tested: <version or unknown>
+```
+
+## Triage Notes (Internal)
+- Root cause hypothesis:
+- Owner:
+- Fix target version:
+- Status: New | Confirmed | In Progress | Fixed | Verified | Closed

--- a/docs/pilots/BETA_INVITE_MESSAGE_v1.2.1-OMEGA.md
+++ b/docs/pilots/BETA_INVITE_MESSAGE_v1.2.1-OMEGA.md
@@ -1,0 +1,45 @@
+# NeuralShell Beta Invite Message (v1.2.1-OMEGA)
+
+## Email Version
+Subject: NeuralShell v1.2.1-OMEGA Beta Invite (Install + Stability Validation)
+
+Hi <Name>,
+
+I’m running a focused beta for NeuralShell and I’d like you in this round.
+
+Build: `v1.2.1-OMEGA`  
+Download: `https://github.com/Z3r0DayZion-install/NeuralShell/releases/tag/v1.2.1-OMEGA`
+
+What I need from you:
+1. Run the one-page checklist.
+2. Report any issue using the bug template.
+
+Test docs:
+- Checklist: `docs/pilots/BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md`
+- Bug Template: `docs/pilots/BETA_BUG_REPORT_TEMPLATE.md`
+
+Expected time:
+- Core pass: 20-30 minutes
+- Optional soak: normal usage over 24 hours
+
+Blockers I care about most:
+- Install/launch failures
+- Crashes/freezes
+- Lost settings or session data
+- Security/trust warnings that look suspicious
+
+If you’re in, I’ll send the test packet and you can start immediately.
+
+Thanks.
+
+## DM / Short Version
+I’m running a beta for `NeuralShell v1.2.1-OMEGA` and need a real install + usage pass.
+
+Download:
+`https://github.com/Z3r0DayZion-install/NeuralShell/releases/tag/v1.2.1-OMEGA`
+
+Use:
+- `docs/pilots/BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md`
+- `docs/pilots/BETA_BUG_REPORT_TEMPLATE.md`
+
+Core pass takes ~20-30 min. Want in?

--- a/docs/pilots/BETA_RUNBOARD_v1.2.1-OMEGA.md
+++ b/docs/pilots/BETA_RUNBOARD_v1.2.1-OMEGA.md
@@ -1,0 +1,36 @@
+# NeuralShell Beta Runboard (v1.2.1-OMEGA)
+
+Use this as the single source of truth for the beta round.
+
+## Targets
+- Invite sent: 10 testers
+- Started: 5 testers
+- Completed checklist: 5 testers
+- P0/P1 blockers before public push: 0
+
+## Tester Tracker
+| Tester | Invite Sent | Started | Completed | Result (`Passed X/9`) | Highest Bug Severity | Notes |
+|---|---|---|---|---|---|---|
+| Tester 01 |  |  |  |  |  |  |
+| Tester 02 |  |  |  |  |  |  |
+| Tester 03 |  |  |  |  |  |  |
+| Tester 04 |  |  |  |  |  |  |
+| Tester 05 |  |  |  |  |  |  |
+| Tester 06 |  |  |  |  |  |  |
+| Tester 07 |  |  |  |  |  |  |
+| Tester 08 |  |  |  |  |  |  |
+| Tester 09 |  |  |  |  |  |  |
+| Tester 10 |  |  |  |  |  |  |
+
+## Bug Triage Queue
+| Bug ID | Title | Severity | Reproducible | Owner | Status | Fix Version |
+|---|---|---|---|---|---|---|
+| BETA-001 |  |  |  |  | New |  |
+| BETA-002 |  |  |  |  | New |  |
+| BETA-003 |  |  |  |  | New |  |
+
+## Exit Criteria
+1. At least 5 checklist completions.
+2. No open `P0` or `P1`.
+3. Any `P2` has a known workaround or a committed fix plan.
+4. Installer, first launch, onboarding memory, settings persistence validated by at least 3 different testers.

--- a/docs/pilots/BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md
+++ b/docs/pilots/BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md
@@ -1,0 +1,66 @@
+# NeuralShell Beta Tester Checklist (One Page)
+
+Build under test: `v1.2.1-OMEGA`  
+Release link: `https://github.com/Z3r0DayZion-install/NeuralShell/releases/tag/v1.2.1-OMEGA`  
+Goal: validate real install/use/restart behavior on non-dev machines.
+
+## Tester Setup
+1. Use a normal user account (not admin terminal workflows unless required by installer).
+2. Use a machine that does not already have your local dev copy running.
+3. Record OS version and security tools (Defender/EDR/AV).
+
+## Execution Checklist
+Mark each as `PASS` or `FAIL` and add notes.
+
+1. Download and trust
+- Download `NeuralShell.Setup.1.2.1-OMEGA.exe` from the release page.
+- Note SmartScreen/AV behavior.
+
+2. Install
+- Run installer with default settings.
+- Confirm install completes without crash/hang.
+
+3. First launch
+- App opens and reaches usable UI in under 30 seconds.
+- No crash or freeze on first launch.
+
+4. Onboarding flow
+- Complete onboarding.
+- Close and reopen app.
+- Confirm onboarding is remembered.
+- Use reset path and confirm onboarding can be shown again.
+
+5. Core interaction
+- Send at least one prompt.
+- Open command palette and toggle theme.
+- Confirm palette closes cleanly and app remains responsive.
+
+6. Persistence
+- Edit profile/settings.
+- Fully close app and relaunch.
+- Confirm profile/settings persisted.
+
+7. Session behavior
+- Create a conversation/session.
+- Restart app.
+- Confirm session history still exists.
+
+8. Stability pass (10 minutes)
+- Keep app open for 10 minutes with normal use.
+- Confirm no crash, blank screen, hard freeze, or runaway CPU.
+
+9. Reinstall check
+- Uninstall app.
+- Reinstall same version.
+- Confirm launch still succeeds.
+
+## Blocker Definition (Stop and Report Immediately)
+- Install fails or app cannot launch.
+- Data/settings disappear unexpectedly.
+- Reproducible crash/freeze on core flow.
+- Security warning appears malicious or unverifiable.
+
+## Submit Back
+1. Checklist result summary: `Passed X/9`.
+2. Any `FAIL` item with exact step number.
+3. Bug report(s) using `docs/pilots/BETA_BUG_REPORT_TEMPLATE.md`.


### PR DESCRIPTION
## Summary\n- add one-page beta tester checklist for v1.2.1-OMEGA\n- add standardized beta bug report template with severity scale\n- add ready-to-send beta invite message (email + DM)\n- add beta runboard tracker for tester progress and blocker triage\n\n## Why\n- makes beta operations immediately executable and repeatable\n- provides consistent bug signal quality for fast triage\n\n## Validation\n- pre-push gate passed locally (lint, flaky test gate, coverage gate, local security gate)