### PR TITLE
ops(beta): add intake issue forms and triage playbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/beta_bug_report.yml
@@ -1,0 +1,99 @@
+name: Beta Bug Report
+description: Report a bug found while testing v1.2.1-OMEGA
+title: "[Beta Bug] <short title>"
+labels:
+  - beta
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for issues found during beta testing of `v1.2.1-OMEGA`.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Pick the highest impact level.
+      options:
+        - P0 (critical: blocked install/launch, data loss, security compromise)
+        - P1 (high: major feature broken, no workaround)
+        - P2 (medium: partial break, workaround exists)
+        - P3 (low: minor friction or cosmetic)
+    validations:
+      required: true
+  - type: input
+    id: build
+    attributes:
+      label: Build
+      description: Keep as v1.2.1-OMEGA unless testing another build.
+      value: v1.2.1-OMEGA
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS version, device info, and AV/EDR if relevant.
+      placeholder: Windows 11 23H2, 32GB RAM, Defender
+    validations:
+      required: true
+  - type: input
+    id: checklist_step
+    attributes:
+      label: Checklist step number
+      description: Step from BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md
+      placeholder: "4"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short explanation of what failed and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Reproduction steps
+      description: Exact steps to reproduce.
+      placeholder: |
+        1. Open app
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_result
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual_result
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: textarea
+    id: frequency
+    attributes:
+      label: Frequency
+      description: Repro rate and whether it is always/intermittent.
+      placeholder: 3/5 runs, intermittent
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Screenshots, logs, error text, or recording links.
+    validations:
+      required: false
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround
+      description: If any.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/beta_test_result.yml
+++ b/.github/ISSUE_TEMPLATE/beta_test_result.yml
@@ -1,0 +1,68 @@
+name: Beta Test Result
+description: Submit completed checklist result for v1.2.1-OMEGA
+title: "[Beta Result] <tester> - <Passed X/9>"
+labels:
+  - beta
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Submit one issue per tester completion using the one-page checklist.
+  - type: input
+    id: tester
+    attributes:
+      label: Tester alias
+      placeholder: tester-01
+    validations:
+      required: true
+  - type: input
+    id: build
+    attributes:
+      label: Build
+      value: v1.2.1-OMEGA
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: Windows 11 23H2, Defender
+    validations:
+      required: true
+  - type: input
+    id: checklist_result
+    attributes:
+      label: Checklist result
+      description: Format as Passed X/9
+      placeholder: Passed 9/9
+    validations:
+      required: true
+  - type: checkboxes
+    id: blockers
+    attributes:
+      label: Blockers observed
+      options:
+        - label: Install failed
+        - label: Launch failed
+        - label: Crash or freeze
+        - label: Data/settings/session loss
+        - label: Security warning appears suspicious
+        - label: No blockers observed
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Include friction points, trust concerns, and UX feedback.
+    validations:
+      required: false
+  - type: textarea
+    id: linked_bugs
+    attributes:
+      label: Linked bug issues
+      description: List issue numbers for any bugs filed from this run.
+      placeholder: "#123, #124"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Beta Tester Checklist
+    url: https://github.com/Z3r0DayZion-install/NeuralShell/blob/master/docs/pilots/BETA_TESTER_CHECKLIST_v1.2.1-OMEGA.md
+    about: Use this one-page checklist before filing results.
+  - name: Beta Invite Packet
+    url: https://github.com/Z3r0DayZion-install/NeuralShell/blob/master/docs/pilots/BETA_INVITE_MESSAGE_v1.2.1-OMEGA.md
+    about: Reuse this to onboard testers quickly.

--- a/docs/pilots/BETA_RUNBOARD_v1.2.1-OMEGA.md
+++ b/docs/pilots/BETA_RUNBOARD_v1.2.1-OMEGA.md
@@ -8,6 +8,11 @@ Use this as the single source of truth for the beta round.
 - Completed checklist: 5 testers
 - P0/P1 blockers before public push: 0
 
+## Operating Links
+- Issue forms: `https://github.com/Z3r0DayZion-install/NeuralShell/issues/new/choose`
+- Triage playbook: `docs/pilots/BETA_TRIAGE_PLAYBOOK_v1.2.1-OMEGA.md`
+- Immutable ledger: `governance/BETA_PILOT_LEDGER_v1.2.1-OMEGA.jsonl`
+
 ## Tester Tracker
 | Tester | Invite Sent | Started | Completed | Result (`Passed X/9`) | Highest Bug Severity | Notes |
 |---|---|---|---|---|---|---|

--- a/docs/pilots/BETA_TRIAGE_PLAYBOOK_v1.2.1-OMEGA.md
+++ b/docs/pilots/BETA_TRIAGE_PLAYBOOK_v1.2.1-OMEGA.md
@@ -1,0 +1,34 @@
+# NeuralShell Beta Triage Playbook (v1.2.1-OMEGA)
+
+Use this playbook to process incoming beta issues with consistent speed and severity.
+
+## Intake Channels
+1. `Beta Bug Report` issue form for defects.
+2. `Beta Test Result` issue form for checklist completion.
+3. `docs/pilots/BETA_RUNBOARD_v1.2.1-OMEGA.md` for aggregated tracking.
+4. `governance/BETA_PILOT_LEDGER_v1.2.1-OMEGA.jsonl` for immutable event log.
+
+## Severity Policy
+- `P0`: install/launch blocked, data loss, security compromise, unrecoverable crash.
+- `P1`: major feature broken with no practical workaround.
+- `P2`: partial break with workaround.
+- `P3`: cosmetic/minor friction with no functional block.
+
+## Triage SLA
+- `P0`: acknowledge in 15 minutes, assign owner immediately, hotfix path same day.
+- `P1`: acknowledge in 60 minutes, assign owner same day.
+- `P2`: acknowledge within 1 business day.
+- `P3`: batch into next patch or UX pass.
+
+## Required Actions Per Bug
+1. Confirm reproducibility with exact steps.
+2. Confirm affected scope (all users vs environment-specific).
+3. Assign owner and target fix version.
+4. Update runboard row and ledger event.
+5. Close only after fix verification on a clean run.
+
+## Exit Gate To Public
+1. Zero open `P0`.
+2. Zero open `P1`.
+3. Any open `P2` has documented workaround and scheduled fix.
+4. At least 5 completed beta result forms.

--- a/governance/BETA_PILOT_LEDGER_v1.2.1-OMEGA.jsonl
+++ b/governance/BETA_PILOT_LEDGER_v1.2.1-OMEGA.jsonl
@@ -1,0 +1,1 @@
+{"event":"beta_round_initialized","build":"v1.2.1-OMEGA","at":"2026-03-09T22:00:00Z","owner":"founder","notes":"Initial beta packet and runboard published."}


### PR DESCRIPTION
## Summary\n- add GitHub issue forms for beta bug reports and beta test results\n- add issue template config with beta packet links\n- add beta triage playbook with severity + SLA\n- add pilot ledger jsonl seed entry\n- update runboard with operating links\n\n## Why\n- enables structured tester intake and faster triage\n- reduces founder overhead during beta operations\n\n## Validation\n- local pre-push gate passed (lint, tests, coverage, security pass)