### PR TITLE
ops(beta): automate severity labeling and critical response

### DIFF
--- a/.github/workflows/beta-triage-automation.yml
+++ b/.github/workflows/beta-triage-automation.yml
@@ -1,0 +1,73 @@
+name: Beta Triage Automation
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  issues: write
+
+jobs:
+  severity_autolabel:
+    if: contains(github.event.issue.title, '[Beta') || contains(join(github.event.issue.labels.*.name, ','), 'beta')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply severity labels from beta form
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || "";
+            const severityLabels = ["P0", "P1", "P2", "P3"];
+
+            const severitySection = body.match(/###\s*Severity\s*\r?\n([^\r\n]+)/i);
+            if (!severitySection) {
+              core.info("No severity section found; skipping.");
+              return;
+            }
+
+            const token = severitySection[1].match(/\bP[0-3]\b/i);
+            if (!token) {
+              core.info("Severity token not found; skipping.");
+              return;
+            }
+
+            const severity = token[0].toUpperCase();
+            const existing = (issue.labels || []).map((label) =>
+              typeof label === "string" ? label : label.name
+            );
+            const retained = existing.filter((label) => !severityLabels.includes(label));
+            const finalLabels = Array.from(new Set([...retained, "beta", severity]));
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: finalLabels
+            });
+
+            core.info(`Applied labels: ${finalLabels.join(", ")}`);
+
+            if (severity === "P0" || severity === "P1") {
+              const marker = "<!-- beta-critical-response -->";
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              const alreadyPosted = comments.data.some((comment) =>
+                String(comment.body || "").includes(marker)
+              );
+              if (!alreadyPosted) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `${marker}\nCritical beta issue detected (${severity}).\n\nNext actions:\n1. Reproduce and confirm scope immediately.\n2. Assign owner and target fix version.\n3. Update runboard + ledger.\n4. Hold public rollout until this is resolved.`
+                });
+              }
+            }


### PR DESCRIPTION
## Summary\n- add beta triage automation workflow\n- auto-apply P0/P1/P2/P3 label from beta bug issue form\n- enforce eta label presence on classified issues\n- auto-comment critical response guidance for P0/P1\n\n## Why\n- removes manual severity tagging overhead\n- speeds reaction time for blocker issues\n\n## Validation\n- local pre-push gate passed